### PR TITLE
variadic templates for oteestream

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,8 @@ namespace yu {
 namespace stream {
 class oteestream : public std::ostream {
  public:
-  oteestream(std::ostream& out1, std::ostream& out2);
+  template<class.. Args>
+  oteestream(Args&&... ostreams);
 };
 
 class iteestream : public std::ostream {
@@ -212,10 +213,12 @@ example: `sample/stream_teestream_sample.cpp`
 {
   std::ostringstream out1;
   std::ostringstream out2;
-  yu::stream::oteestream ots(out1, out2);
+  std::ostringstream out3;
+  yu::stream::oteestream ots(out1, out2, out3);
   ots << "Hello " << "T-stream" << " World!";
   std::cout << "out1 = " << out1.str() << std::endl;
   std::cout << "out2 = " << out2.str() << std::endl;
+  std::cout << "out3 = " << out3.str() << std::endl;
 }
 {
   std::istringstream iss("Hello World!");
@@ -230,10 +233,13 @@ example: `sample/stream_teestream_sample.cpp`
 }
 // out1 = Hello T-stream World!
 // out2 = Hello T-stream World!
+// out3 = Hello T-stream World!
 // str = Hello
 // oss = Hello World!
 // str = World!
 ```
+
+see also: `app/sha2.cpp`
 
 ### base64.hpp
 

--- a/app/sha2.cpp
+++ b/app/sha2.cpp
@@ -12,16 +12,10 @@ void print_digest(const std::string& filename, std::istream& in) {
   yu::digest::sha512_stream sha512s;
   yu::digest::sha512_224_stream sha512_224s;
   yu::digest::sha512_256_stream sha512_256s;
-  {
-    yu::stream::oteestream t1(sha224s, sha256s);
-    yu::stream::oteestream t2(sha384s, sha512s);
-    yu::stream::oteestream t3(sha512_224s, sha512_256s);
-    yu::stream::oteestream t4(t1, t2);
-    yu::stream::oteestream tos(t3, t4);
-    tos << in.rdbuf();
-    in.sync();
-    tos.flush();
-  }
+
+  yu::stream::oteestream tos(sha224s, sha256s, sha384s, sha512s, sha512_224s, sha512_256s);
+  tos << in.rdbuf() << std::flush;
+
   std::cout << "SHA224(" << filename << ")= " << sha224s.hash_hex() << std::endl;
   std::cout << "SHA256(" << filename << ")= " << sha256s.hash_hex() << std::endl;
   std::cout << "SHA384(" << filename << ")= " << sha384s.hash_hex() << std::endl;

--- a/sample/stream_teestream_sample.cpp
+++ b/sample/stream_teestream_sample.cpp
@@ -7,10 +7,12 @@ int main() {
   {
     std::ostringstream out1;
     std::ostringstream out2;
-    yu::stream::oteestream ots(out1, out2);
+    std::ostringstream out3;
+    yu::stream::oteestream ots(out1, out2, out3);
     ots << "Hello " << "T-stream" << " World!";
     std::cout << "out1 = " << out1.str() << std::endl;
     std::cout << "out2 = " << out2.str() << std::endl;
+    std::cout << "out3 = " << out3.str() << std::endl;
   }
   {
     std::istringstream iss("Hello World!");

--- a/test/stream_teestream_test.cpp
+++ b/test/stream_teestream_test.cpp
@@ -8,12 +8,14 @@ class TeeStreamTest : public yu::Test {
 TEST(TeeStreamTest, testOTeeStream) {
   std::ostringstream out1;
   std::ostringstream out2;
-  yu::stream::oteestream ots(out1, out2);
+  std::ostringstream out3;
+  yu::stream::oteestream ots(out1, out2, out3);
 
   std::istringstream iss("Hello World!!");
   ots << iss.rdbuf();
   EXPECT("Hello World!!", ==, out1.str());
   EXPECT("Hello World!!", ==, out2.str());
+  EXPECT("Hello World!!", ==, out3.str());
 }
 
 TEST(TeeStreamTest, testITeeStream) {


### PR DESCRIPTION
可変長テンプレートを使って `oteestream` が複数の `std::ostream` を受けられるように。