### PR TITLE
Feature/http simple server

### DIFF
--- a/yu/http/server_stream.hpp
+++ b/yu/http/server_stream.hpp
@@ -21,9 +21,25 @@ namespace http {
 namespace detail {
 const static std::unordered_map<int,std::string> kResponseStatusMessage = {
   { 200, "OK" },
+  { 201, "Created" },
+  { 202, "Accepted" },
+  { 204, "No Content" },
   { 300, "Multiple Choices" },
+  { 301, "Moved Permanently" },
+  { 302, "Found" },
+  { 303, "See Other" },
+  { 304, "Not Modified" },
+  { 307, "Temporary Redirect" },
+  { 308, "Permanent Redirect" },
   { 400, "Bad Request" },
+  { 401, "Unauthorized" },
+  { 402, "Payment Required" },
+  { 403, "Forbidden" },
+  { 404, "Not Found" },
+  { 405, "Method Not Allowed" },
+  { 408, "Request Timeout" },
   { 500, "Internal Server Error" },
+  { 503, "Service Unavailable" },
 };
 }  // detail
 
@@ -45,7 +61,7 @@ class ServerStream {
     line = yu::string::rstrip(line, "\r");
     std::vector<std::string> requst_line_tokens = yu::string::split(line, ' ', false, 3);
     if (requst_line_tokens.size() != 3) {
-      throw TransferError("invalid request line: fee tokens");
+      throw TransferError("invalid request line: fee tokens: request line='" + line + "'");
     }
 
     Header header;
@@ -75,6 +91,12 @@ class ServerStream {
   const std::string& request_method() const { return request_method_; }
   const std::string& request_target() const { return request_target_; }
   const std::string& request_version() const { return request_version_; }
+  std::string request_line() const {
+    if (!request_parsed_ && !response_header_sent_) {
+      throw std::runtime_error("request not parsed yet");
+    }
+    return request_method_ + " " + request_target_ + " " + request_version_;
+  }
   const Header& request_header() const { return request_header_; }
 
   // Response
@@ -91,6 +113,11 @@ class ServerStream {
     } else {
       response_status_message_ = messgae;
     }
+  }
+  int get_status() const { return response_status_; }
+  const std::string& get_status_message() const { return response_status_message_; }
+  std::string status_line() const {
+    return std::to_string(response_status_) + " " + response_status_message_;
   }
 
   void set_header(const std::string& key, const std::string& value) {

--- a/yu/http/simple_server.hpp
+++ b/yu/http/simple_server.hpp
@@ -1,0 +1,314 @@
+// Copyright 2025 TAKEI Yuya (https://github.com/takei-yuya/)
+#ifndef YU_HTTP_SIMPLE_SERVER_HPP_
+#define YU_HTTP_SIMPLE_SERVER_HPP_
+
+#include <cerrno>
+#include <cstring>
+#include <csignal>
+
+#include <thread>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "../stream/fdstream.hpp"
+#include "server_stream.hpp"
+
+namespace yu {
+namespace http {
+
+namespace detail {
+class FDCloser {
+ public:
+  explicit FDCloser(int fd) : fd_(fd) {}
+  ~FDCloser() { Close(); }
+
+  int Release() {
+    int old = fd_;
+    fd_ = -1;
+    return old;
+  }
+
+  void Close() {
+    if (fd_ != -1) {
+      ::close(Release());
+    }
+  }
+
+ private:
+  int fd_;
+};
+
+void raise_errno(const std::string& func) {
+  std::vector<char> buf(256);
+  std::string err = strerror_r(errno, buf.data(), buf.size());
+  throw std::runtime_error(func + " failed: " + err);
+}
+
+std::string format_time(const std::chrono::system_clock::time_point& tp,
+                        const std::string& format = "%Y-%m-%d %H:%M:%S.%N") {
+  time_t t = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+  auto subsec = tp - std::chrono::system_clock::from_time_t(t);
+  struct tm tm;
+  localtime_r(&t, &tm);
+
+  // support %N (nanoseconds)
+  std::ostringstream nano_oss;
+  nano_oss << std::setw(9) << std::setfill('0')
+           << std::chrono::duration_cast<std::chrono::nanoseconds>(subsec).count();
+  std::string fmt = format;
+  size_t pos = fmt.find("%N");
+  if (pos != std::string::npos) {
+    fmt.replace(pos, 2, nano_oss.str());
+  }
+
+  std::ostringstream oss;
+  oss << std::put_time(&tm, fmt.c_str());
+  return oss.str();
+}
+}  // namespace detail
+
+class WidgetBase {
+ public:
+  virtual ~WidgetBase() = default;
+  // Return true if handled
+  // WidgetBase should not read request body when it does not handle the request (and return false).
+  virtual bool handle(ServerStream& stream, std::istream& request_body) = 0;
+};
+using WidgetPtr = std::shared_ptr<WidgetBase>;
+
+
+class SimpleWidget : public WidgetBase {
+ public:
+  void add_content(const std::string& path,
+                   const std::string& content_type,
+                   const std::string& content,
+                   bool expand_template = false) {
+    contents_[path] = {content_type, content, expand_template};
+  }
+
+  bool handle(ServerStream& server_stream, std::istream&) override {
+    if (server_stream.request_method() != "GET" &&
+        server_stream.request_method() != "HEAD") {
+      return false;
+    }
+    std::string path = server_stream.request_target();
+    auto it = contents_.find(path);
+    if (it == contents_.end()) {
+      return false;
+    }
+    const auto& content_type_ = it->second.content_type;
+    const auto& content_ = it->second.content;
+    bool expand_template_ = it->second.expand_template;
+
+    server_stream.set_status(200, "OK");
+    server_stream.set_header("Content-Type", content_type_);
+    server_stream.set_header("Connection", "close");
+    auto response_stream = server_stream.send_header();
+
+    if (server_stream.request_method() == "HEAD") {
+      server_stream.send_header();  // send header only
+      return true;
+    }
+
+    if (expand_template_) {
+      std::unordered_map<std::string, std::string> variables;
+
+      std::string host = "unknown";
+      if (server_stream.request_header().has("Host")) {
+        host = server_stream.request_header().field("Host");
+      }
+      variables["host"] = host;
+
+      *response_stream << replace_template(content_, variables);
+    } else {
+      *response_stream << content_;
+    }
+
+    return true;
+  }
+
+ private:
+  std::string replace_template(const std::string& content, const std::unordered_map<std::string, std::string>& variables) const {
+    std::string result = content;
+    for (const auto& var : variables) {
+      std::string placeholder = "${" + var.first + "}";
+      size_t pos = 0;
+      while ((pos = result.find(placeholder, pos)) != std::string::npos) {
+        result.replace(pos, placeholder.size(), var.second);
+        pos += var.second.size();
+      }
+    }
+    return result;
+  }
+
+  struct Content {
+    std::string content_type;
+    std::string content;
+    bool expand_template;
+  };
+  std::unordered_map<std::string, Content> contents_;
+};
+using SimpleWidgetPtr = std::shared_ptr<SimpleWidget>;
+
+class ChainWidget : public WidgetBase {
+ public:
+  ChainWidget(WidgetPtr first, WidgetPtr second)
+    : first_(first), second_(second) {
+    if (!first_ || !second_) {
+      throw std::invalid_argument("invalid widget (nullptr)");
+    }
+  }
+
+  bool handle(ServerStream& stream, std::istream& request_body) override {
+    if (first_->handle(stream, request_body)) {
+      return true;
+    }
+    return second_->handle(stream, request_body);
+  }
+
+ private:
+  WidgetPtr first_;
+  WidgetPtr second_;
+};
+WidgetPtr operator|(WidgetPtr first, WidgetPtr second) {
+  return std::make_shared<ChainWidget>(first, second);
+}
+
+
+#define SYSCALL(ret, expr) \
+  while ((ret = (expr)) == -1) { \
+    if (errno == EINTR) continue; \
+    perror(#expr); \
+    exit(EXIT_FAILURE); \
+  }
+
+class SimpleServer {
+ public:
+  static constexpr int kBacklog = 5;
+  SimpleServer(int port, WidgetPtr widget, int catch_all_status = 404, int backlog = kBacklog)
+    : port_(port), widget_(widget), catch_all_status_(catch_all_status), backlog_(backlog) {
+    if (!widget_) {
+      throw std::invalid_argument("invalid widget (nullptr)");
+    }
+  }
+
+  void run() {
+    // TODO: logger
+    std::cerr << "Starting server on port " << port_ << "..." << std::endl;
+
+    signal(SIGPIPE, SIG_IGN);  // ignore SIGPIPE
+
+    int ret;
+
+    // create socket
+    int server_fd;
+    SYSCALL(server_fd, ::socket(AF_INET6, SOCK_STREAM, 0));
+    if (server_fd < 0) {
+      detail::raise_errno("socket");
+    }
+    detail::FDCloser server_fd_closer(server_fd);
+
+    // set socket options
+    int opt = 1;
+    SYSCALL(ret, ::setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)));
+    if (ret < 0) {
+      detail::raise_errno("setsockopt");
+    }
+    opt = 0;
+    SYSCALL(ret, ::setsockopt(server_fd, IPPROTO_IPV6, IPV6_V6ONLY, &opt, sizeof(opt)));
+    if (ret < 0) {
+      detail::raise_errno("setsockopt");
+    }
+
+    // bind
+    struct sockaddr_in6 addr;
+    std::memset(&addr, 0, sizeof(addr));
+    addr.sin6_family = AF_INET6;
+    addr.sin6_addr = in6addr_any;  // :: (all interfaces)
+    addr.sin6_port = htons(port_);
+    SYSCALL(ret, ::bind(server_fd, (struct sockaddr*)&addr, sizeof(addr)));
+    if (ret < 0) {
+      detail::raise_errno("bind");
+    }
+
+    // listen
+    SYSCALL(ret, ::listen(server_fd, backlog_));
+    if (ret < 0) {
+      detail::raise_errno("listen");
+    }
+
+    while (true) {
+      struct sockaddr_in6 client_addr;
+      socklen_t client_addr_len = sizeof(client_addr);
+      int client_fd;
+      SYSCALL(client_fd, ::accept(server_fd, (struct sockaddr*)&client_addr, &client_addr_len));
+      if (client_fd < 0) {
+        detail::raise_errno("accept");
+      }
+      std::string client_ip = "[unknown]";
+      std::string client_port = "0";
+      {
+        char host[NI_MAXHOST];
+        char service[NI_MAXSERV];
+        int rc = getnameinfo((struct sockaddr*)&client_addr, client_addr_len,
+                             host, sizeof(host),
+                             service, sizeof(service),
+                             NI_NUMERICHOST | NI_NUMERICSERV);
+        if (rc == 0) {
+          client_ip = host;
+          client_port = service;
+        }
+      }
+      std::cerr << client_fd << ": Accepted connection from " << client_ip << ":" << client_port << std::endl;
+
+      std::thread(&SimpleServer::process, this, client_fd).detach();
+    }
+  }
+
+  void process(int client_fd) {
+    auto start_time = std::chrono::system_clock::now();
+    std::cerr << client_fd << ": Start thread for client_fd: " << client_fd << " at " << detail::format_time(start_time) << std::endl;
+    detail::FDCloser client_fd_closer(client_fd);
+    try {
+      yu::stream::fdstream stream(client_fd);
+      yu::http::ServerStream server_stream(stream);
+      auto request_stream = server_stream.parse_request();
+
+      std::cerr << client_fd << ":   Processing request: " << server_stream.request_line() << std::endl;
+      std::cerr << client_fd << ":   Headers:" << std::endl;
+      for (const auto& field : server_stream.request_header().field_names()) {
+        std::cerr << client_fd << ":     " << field << ": " << server_stream.request_header().field(field) << std::endl;
+      }
+      if (!widget_->handle(server_stream, *request_stream)) {
+        // Not handled, return catch-all status
+        server_stream.set_status(catch_all_status_);
+        server_stream.set_header("Content-Type", "text/plain; charset=utf-8");
+        server_stream.set_header("Connection", "close");
+        auto response_stream = server_stream.send_header();
+        *response_stream << server_stream.status_line() << "\n";
+      }
+      std::cerr << client_fd << ":   Finished request: " << server_stream.status_line() << std::endl;
+    } catch (const std::exception& e) {
+      std::cerr << client_fd << ":   Error: " << e.what() << std::endl;
+    }
+    auto end_time = std::chrono::system_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time);
+    std::cerr << client_fd << ": End thread for client_fd: " << client_fd << " at " << detail::format_time(end_time) << " (duration: " << duration.count() << " ms)" << std::endl;
+  }
+
+ private:
+  int port_;
+  WidgetPtr widget_;
+  int catch_all_status_;
+  int backlog_;
+};
+
+#undef SYSCALL
+
+}  // namespace http
+}  // namespace yu
+
+
+#endif  // YU_HTTP_SIMPLE_SERVER_HPP_

--- a/yu/lang/unique_resource.hpp
+++ b/yu/lang/unique_resource.hpp
@@ -1,0 +1,139 @@
+// Copyright 2025 TAKEI Yuya (https://github.com/takei-yuya/)
+#ifndef YU_LANG_UNIQUE_RESOURCE_HPP_
+#define YU_LANG_UNIQUE_RESOURCE_HPP_
+
+#include <utility>
+#include <type_traits>
+
+#if defined(__has_cpp_attribute)
+#  if __has_cpp_attribute(no_unique_address)
+#    define YU_NO_UNIQUE_ADDRESS [[no_unique_address]]
+#  else
+#    define YU_NO_UNIQUE_ADDRESS
+#  endif
+#  if __has_cpp_attribute(nodiscard)
+#    define YU_NODISCARD [[nodiscard]]
+#  else
+#    define YU_NODISCARD
+#  endif
+#else
+#  define YU_NO_UNIQUE_ADDRESS
+#  define YU_NODISCARD
+#endif
+
+namespace yu {
+namespace lang {
+
+/**
+ * @brief A RAII wrapper for a resource with a custom deleter.
+ * The resource is released when the UniqueResource is destroyed.
+ * @tparam T The type of the resource.
+ * @tparam F The type of the deleter function/functor. It should be callable with a single argument of type T.
+ */
+template <typename T, typename F>
+class UniqueResource {
+ public:
+  /**
+   * @brief Constructs a UniqueResource that takes ownership of the given resource and deleter.
+   * @param resource The resource to manage.
+   * @param deleter The deleter function/functor to call when the resource is released.
+   */
+  UniqueResource(T resource, F deleter) noexcept
+    : resource_(std::move(resource)), deleter_(std::move(deleter)), deleted_(false) {}
+  /**
+   * @brief Destructor. Calls the deleter on the resource if it has not been released.
+   */
+  ~UniqueResource() {
+    reset();
+  }
+
+  // Movable
+  UniqueResource(UniqueResource&& other) noexcept
+    : resource_(std::move(other.resource_)),
+      deleter_(std::move(other.deleter_)),
+      deleted_(other.deleted_) {
+    (void)other.release();
+  }
+  UniqueResource& operator=(UniqueResource&& other) noexcept {
+    if (this != &other) {
+      reset();
+      resource_ = std::move(other.resource_);
+      deleter_ = std::move(other.deleter_);
+      deleted_ = other.deleted_;
+      (void)other.release();
+    }
+    return *this;
+  }
+
+  // Non-copyable
+  UniqueResource(const UniqueResource&) = delete;
+  UniqueResource& operator=(const UniqueResource&) = delete;
+
+  /**
+   * @brief Releases the managed resource by calling the deleter if it has not been released yet.
+   * After calling this function, the UniqueResource no longer manages the resource.
+   */
+  void reset() {
+    if (!deleted_) {
+      deleted_ = true;
+      deleter_(resource_);
+    }
+  }
+
+  /**
+   * @brief Releases the current resource (if any) and takes ownership of a new resource.
+   * @param resource The new resource to manage.
+   */
+  void reset(T resource) {
+    reset();
+    resource_ = std::move(resource);
+    deleted_ = false;
+  }
+
+  /**
+   * @brief Releases ownership of the managed resource without calling the deleter.
+   * After calling this function, the UniqueResource no longer manages the resource.
+   * @return The managed resource.
+   */
+  YU_NODISCARD T release() noexcept {
+    deleted_ = true;
+    return std::move(resource_);
+  }
+
+  /**
+   * @brief Returns a const reference to the managed resource.
+   * @return A const reference to the managed resource.
+   */
+  const T& get() const noexcept { return resource_; }
+
+  /**
+   * @brief Implicit conversion operator to const T&.
+   * Allows using UniqueResource in places where a const T& is expected.
+   * @return A const reference to the managed resource.
+   */
+  operator const T&() const noexcept { return resource_; }
+
+  /**
+   * @brief Returns a const reference to the deleter function/functor.
+   * @return A const reference to the deleter function/functor.
+   */
+  const F& get_deleter() const noexcept { return deleter_; }
+
+ private:
+  T resource_;
+  YU_NO_UNIQUE_ADDRESS F deleter_;
+  bool deleted_;
+};
+
+template <typename T, typename F>
+UniqueResource<T, F> make_unique_resource(T resource, F deleter) noexcept {
+  return UniqueResource<T, F>(std::move(resource), std::move(deleter));
+}
+
+}  // namespace lang
+}  // namespace yu
+
+#undef YU_NODISCARD
+#undef YU_NO_UNIQUE_ADDRESS
+
+#endif  // YU_LANG_UNIQUE_RESOURCE_HPP_

--- a/yu/lang/unique_resource.hpp
+++ b/yu/lang/unique_resource.hpp
@@ -43,8 +43,12 @@ class UniqueResource {
   /**
    * @brief Destructor. Calls the deleter on the resource if it has not been released.
    */
-  ~UniqueResource() {
-    reset();
+  ~UniqueResource() noexcept {
+    try {
+      reset();
+    } catch (...) {
+      // swallow exceptions in destructor
+    }
   }
 
   // Movable


### PR DESCRIPTION
This pull request introduces several improvements and new features to the HTTP server implementation. The main changes include expanding HTTP status code support, enhancing error reporting, adding new API methods to `ServerStream`, and introducing two new files: `yu/http/simple_server.hpp` for a simple HTTP server and widget framework, and `yu/lang/unique_resource.hpp` for RAII resource management. These updates make the server more robust, flexible, and easier to use.

**HTTP Status Code Support and Error Handling:**
* Expanded the set of supported HTTP status codes in the internal status message map to cover more standard codes, improving response accuracy and flexibility.
* Improved error reporting for invalid HTTP request lines by including the actual request line in the exception message, aiding debugging.

**API Enhancements for `ServerStream`:**
* Added new accessor methods to `ServerStream`, including `request_line()`, `get_status()`, `get_status_message()`, and `status_line()`, making it easier to retrieve request and response details programmatically. [[1]](diffhunk://#diff-c0c7c0706198c95ec6d921776abe7c168d8fdca608f59accd03facbdb6e6f5f3R94-R99) [[2]](diffhunk://#diff-c0c7c0706198c95ec6d921776abe7c168d8fdca608f59accd03facbdb6e6f5f3R117-R121)

**New Simple HTTP Server and Widget Framework:**
* Introduced `yu/http/simple_server.hpp`, which provides a simple HTTP server implementation, a widget-based request handler framework, and utility functions for error handling and time formatting. This includes the `SimpleServer`, `WidgetBase`, `SimpleWidget`, and `ChainWidget` classes for flexible server-side routing and content serving.

**RAII Resource Management Utility:**
* Added `yu/lang/unique_resource.hpp`, a header-only utility for managing resources with custom deleters using RAII, ensuring safe and automatic resource cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 新機能
  * HTTPステータス対応を拡充（201/202/204、各種リダイレクト、401〜405、408、503 など）。
  * リクエストラインおよび現在のレスポンスステータスを確認できる読み取り機能を追加。
  * 無効なリクエストライン時のエラーメッセージを明確化（実際の行を表示）。
  * シンプルなHTTPサーバーを追加：ウィジェット連結、静的/テンプレートコンテンツ配信、GET/HEAD対応、接続ごとの並行処理。
  * RAIIベースのリソース管理ユーティリティを追加し、安全な解放と移譲をサポート。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->